### PR TITLE
Package mirror-elpa as a composite action; move the mirroring schedule to the mirror repo

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,37 +1,33 @@
 name: CI
 
+# This repository hosts the mirror-elpa tool and composite action; it no longer
+# runs the mirroring cron itself. Scheduling the mirror from a repository that
+# rarely changes makes GitHub auto-disable the schedule after 60 days of
+# inactivity. The cron now lives in the mirror repository instead -- see
+# examples/elpa-mirror.yaml and the "GitHub Action" section of the README.
+
 on:
   push:
     paths-ignore:
-    - '**/*.md'
-    - '**/*.org'
+      - '**/*.md'
+      - '**/*.org'
     branches:
       - master
-  schedule:
-    - cron:  '0 */4 * * *'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.org'
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        emacs_version:
-          - 28.1
-        host:
-          - github
-          # - gitlab
-
     steps:
-    - uses: purcell/setup-emacs@master
-      with:
-        version: ${{ matrix.emacs_version }}
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v1
+      - name: Syntax check
+        run: |
+          bash -n mirror-elpa
+          bash -n configure
 
-    - name: sync packages
-      env:
-        ACCESS_LOGIN: ${{ secrets.ACCESS_LOGIN }}
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        GITLAB_USER: ${{ secrets.GITLAB_ACCESS_LOGIN }}
-        GITLAB_ACCESS_TOKEN: ${{ secrets.GITLAB_ACCESS_TOKEN }}
-      run: ./mirror-elpa .ci/${{ matrix.host }}.config
+      - name: ShellCheck
+        run: shellcheck --severity=error mirror-elpa configure

--- a/README.org
+++ b/README.org
@@ -70,6 +70,69 @@ should help you with token creation.
   ./configure
 #+end_src
 
+** GitHub Action
+
+=mirror-elpa= ships as a composite GitHub Action, so the mirroring can run on a
+schedule directly from the repository that holds the mirror. Running the cron
+from the mirror repository itself keeps that repository active (every successful
+run pushes a snapshot commit), which prevents GitHub from [[https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-and-enabling-a-workflow][automatically
+disabling scheduled workflows]] after 60 days of inactivity. Scheduling it from a
+rarely-changing tooling repository instead means the schedule keeps getting
+disabled and has to be re-enabled by hand.
+
+Add a workflow like the following to your mirror repository, for example
+=d12frosted/elpa-mirror= at =.github/workflows/mirror.yaml= (a ready-to-copy
+version lives in [[file:examples/elpa-mirror.yaml][examples/elpa-mirror.yaml]]):
+
+#+begin_src yaml
+  name: mirror
+  on:
+    schedule:
+      - cron: '0 */4 * * *'
+    workflow_dispatch:
+  permissions:
+    contents: write
+  jobs:
+    mirror:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: d12frosted/mirror-elpa@master
+          with:
+            mirror_owner: d12frosted
+            mirror_repo: elpa-mirror
+            access_token: ${{ secrets.GITHUB_TOKEN }}
+            emacs_version: '28.1'
+#+end_src
+
+Because the workflow pushes to its own repository, the built-in =GITHUB_TOKEN=
+is enough -- there is no personal access token to create or rotate. Make sure
+the job grants =contents: write=.
+
+*** Inputs
+
+| Input                     | Required | Default                                | Description                                              |
+|---------------------------+----------+----------------------------------------+----------------------------------------------------------|
+| =mirror_owner=            | yes      |                                        | Owner of the mirror repository.                          |
+| =mirror_repo=             | yes      |                                        | Name of the mirror repository.                           |
+| =access_token=            | yes      |                                        | Token used to authenticate the push.                     |
+| =access_login=            | no       | =x-access-token=                       | Login paired with =access_token=.                        |
+| =mirror_host=             | no       | =github.com=                           | Git host of the mirror remote.                           |
+| =mirror_repo_branch_name= | no       | =master=                               | Branch to push to.                                       |
+| =commit_name=             | no       | =mirror-elpa=                          | Committer name.                                          |
+| =commit_email=            | no       | =mirror-elpa@users.noreply.github.com= | Committer email.                                         |
+| =commit_gpgsign=          | no       | =false=                                | Whether to GPG-sign snapshot commits.                   |
+| =mirror_path=             | no       | temporary directory                    | Local working path for the mirror checkout.             |
+| =elpa_clone_path=         | no       | =$HOME/.cache/elpa-clone=              | Local path for the elpa-clone tool.                     |
+| =squash_old_commits=      | no       | =false=                                | Whether to squash old commits.                          |
+| =squash_before=           | no       | =1 year=                               | Squash commits older than this duration.                |
+| =emacs_version=           | no       |                                        | If set, install this Emacs via =purcell/setup-emacs=.    |
+
+The runner needs =git= and =rsync= available (both are preinstalled on GitHub's
+=ubuntu-latest= images) and an Emacs -- either set =emacs_version= to have the
+action install one, or provide your own beforehand. To mirror to GitLab, set
+=mirror_host: gitlab.com= and pass a GitLab token (with a matching
+=access_login=) via =access_token=.
+
 ** Using with CRON
 
 #+BEGIN_SRC bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,130 @@
+name: 'mirror-elpa'
+description: 'Mirror Emacs Lisp package archives (GNU/NonGNU ELPA, MELPA, Org) into a Git repository.'
+author: 'd12frosted'
+branding:
+  icon: 'package'
+  color: 'purple'
+
+inputs:
+  mirror_owner:
+    description: 'Owner of the mirror repository (e.g. d12frosted).'
+    required: true
+  mirror_repo:
+    description: 'Name of the mirror repository (e.g. elpa-mirror).'
+    required: true
+  access_token:
+    description: >-
+      Token used to authenticate the push to the mirror repository. When the
+      workflow lives in the mirror repository itself, the built-in
+      ${{ secrets.GITHUB_TOKEN }} is enough (requires "contents: write").
+    required: true
+  access_login:
+    description: >-
+      Login paired with access_token. Use "x-access-token" together with a
+      GITHUB_TOKEN; for a personal access token any username works.
+    required: false
+    default: 'x-access-token'
+  mirror_host:
+    description: 'Git host of the mirror remote.'
+    required: false
+    default: 'github.com'
+  mirror_repo_branch_name:
+    description: 'Branch of the mirror repository to push to.'
+    required: false
+    default: 'master'
+  commit_name:
+    description: 'Committer name used for snapshot commits.'
+    required: false
+    default: 'mirror-elpa'
+  commit_email:
+    description: 'Committer email used for snapshot commits.'
+    required: false
+    default: 'mirror-elpa@users.noreply.github.com'
+  commit_gpgsign:
+    description: 'Whether to GPG-sign snapshot commits.'
+    required: false
+    default: 'false'
+  mirror_path:
+    description: 'Local working path for the mirror checkout. Defaults to a temporary directory.'
+    required: false
+    default: ''
+  elpa_clone_path:
+    description: 'Local path where the elpa-clone tool is cloned. Defaults to $HOME/.cache/elpa-clone.'
+    required: false
+    default: ''
+  squash_old_commits:
+    description: 'Whether to squash old commits (true/false).'
+    required: false
+    default: 'false'
+  squash_before:
+    description: 'Squash commits older than this human-readable duration (e.g. "1 year").'
+    required: false
+    default: '1 year'
+  emacs_version:
+    description: >-
+      If set, install this Emacs version via purcell/setup-emacs before
+      mirroring. Leave empty to use an Emacs that is already on PATH.
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Emacs
+      if: ${{ inputs.emacs_version != '' }}
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{ inputs.emacs_version }}
+
+    - name: Mirror ELPA archives
+      shell: bash
+      env:
+        MIRROR_HOST: ${{ inputs.mirror_host }}
+        MIRROR_OWNER: ${{ inputs.mirror_owner }}
+        MIRROR_REPO: ${{ inputs.mirror_repo }}
+        MIRROR_BRANCH: ${{ inputs.mirror_repo_branch_name }}
+        ACCESS_LOGIN: ${{ inputs.access_login }}
+        ACCESS_TOKEN: ${{ inputs.access_token }}
+        COMMIT_NAME: ${{ inputs.commit_name }}
+        COMMIT_EMAIL: ${{ inputs.commit_email }}
+        COMMIT_GPGSIGN: ${{ inputs.commit_gpgsign }}
+        MIRROR_PATH: ${{ inputs.mirror_path }}
+        ELPA_CLONE_PATH: ${{ inputs.elpa_clone_path }}
+        SQUASH_OLD_COMMITS: ${{ inputs.squash_old_commits }}
+        SQUASH_BEFORE: ${{ inputs.squash_before }}
+      run: |
+        set -euo pipefail
+
+        # Build a config file for the mirror-elpa script from the action inputs.
+        # The values are referenced (not interpolated) so secrets and tokens
+        # with special characters never end up in the generated source.
+        cfg="$(mktemp)"
+        trap 'rm -f "$cfg"' EXIT
+
+        cat >"$cfg" <<'CONFIG'
+        mirror_host="${MIRROR_HOST}"
+        mirror_owner="${MIRROR_OWNER}"
+        mirror_repo="${MIRROR_REPO}"
+        mirror_repo_branch_name="${MIRROR_BRANCH}"
+        access_login="${ACCESS_LOGIN}"
+        access_token="${ACCESS_TOKEN}"
+        commit_name="${COMMIT_NAME}"
+        commit_email="${COMMIT_EMAIL}"
+        squash_old_commits="${SQUASH_OLD_COMMITS}"
+        squash_before="${SQUASH_BEFORE}"
+
+        function git_config_hook {
+          git config commit.gpgsign "${COMMIT_GPGSIGN}"
+        }
+        CONFIG
+
+        # Only override these paths when explicitly provided, otherwise let the
+        # script fall back to its own defaults (temp dir / $HOME/.cache).
+        if [ -n "${MIRROR_PATH}" ]; then
+          printf 'mirror_path=%q\n' "${MIRROR_PATH}" >>"$cfg"
+        fi
+        if [ -n "${ELPA_CLONE_PATH}" ]; then
+          printf 'elpa_clone_path=%q\n' "${ELPA_CLONE_PATH}" >>"$cfg"
+        fi
+
+        bash "${GITHUB_ACTION_PATH}/mirror-elpa" "$cfg"

--- a/examples/elpa-mirror.yaml
+++ b/examples/elpa-mirror.yaml
@@ -1,0 +1,59 @@
+# Scheduled mirroring workflow for the *mirror* repository.
+#
+# Copy this file into the repository that holds the mirror (e.g.
+# d12frosted/elpa-mirror) at:
+#
+#     .github/workflows/mirror.yaml
+#
+# Running the cron from the mirror repository itself keeps that repository
+# active (every successful run pushes a snapshot commit), so GitHub never
+# auto-disables the scheduled workflow after 60 days of inactivity -- which is
+# what happens when the cron lives in the tooling repository (mirror-elpa).
+#
+# Because the workflow pushes to its own repository, the built-in GITHUB_TOKEN
+# is enough; there is no personal access token to create or rotate. The job
+# must grant "contents: write".
+
+name: mirror
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Avoid overlapping runs; let an in-progress mirror finish before the next one.
+concurrency:
+  group: mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: d12frosted/mirror-elpa@master
+        with:
+          mirror_owner: d12frosted
+          mirror_repo: elpa-mirror
+          access_login: x-access-token
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_name: Golem
+          commit_email: golem@d12frosted.io
+          emacs_version: '28.1'
+
+      # --- Mirroring to GitLab as well? -----------------------------------
+      # The same repository can be mirrored elsewhere by adding another step
+      # with a host + token for that remote. GITHUB_TOKEN only works for this
+      # GitHub repository, so GitLab needs its own credentials in secrets:
+      #
+      # - uses: d12frosted/mirror-elpa@master
+      #   with:
+      #     mirror_host: gitlab.com
+      #     mirror_owner: d12frosted
+      #     mirror_repo: elpa-mirror
+      #     access_login: ${{ secrets.GITLAB_USER }}
+      #     access_token: ${{ secrets.GITLAB_ACCESS_TOKEN }}
+      #     commit_name: Golem
+      #     commit_email: golem@d12frosted.io


### PR DESCRIPTION
## Problem

The scheduled mirroring runs from this tooling repository, which rarely changes. GitHub [auto-disables scheduled workflows after 60 days of repository inactivity](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-and-enabling-a-workflow), so the cron keeps getting disabled and has to be re-enabled by hand. Meanwhile all the real activity (a snapshot commit every ~4h) lands in the separate `d12frosted/elpa-mirror` data repo.

## Fix

Package the tool as a **composite action** so the schedule can run from the mirror repository itself, which is always active because every successful run pushes a snapshot commit — so GitHub never disables it.

The action is a thin adapter: it maps inputs → a generated config file → the **unchanged** `mirror-elpa` script. The script already fresh-clones the mirror repo, so it doesn't depend on where it runs. Input values are passed **by reference** (not interpolated into the generated config), so tokens with special characters can't break the config or inject shell commands.

## Changes

- **`action.yml`** — composite action with inputs for host/owner/repo, credentials, committer identity, squash options, gpgsign, and an optional `emacs_version` (installs Emacs via `purcell/setup-emacs` when set).
- **`examples/elpa-mirror.yaml`** — ready-to-copy scheduled workflow for the mirror repo; pushes to itself with the built-in `GITHUB_TOKEN` (no PAT to rotate).
- **`.github/workflows/main.yaml`** — drop the mirroring cron; lint the scripts on push/PR instead.
- **`README.org`** — document the action, its inputs, and the rationale.

The `mirror-elpa` script itself is untouched, so the CRON/local config-file usage keeps working identically.

## Validation

- All YAML parses; the embedded heredoc dedents correctly (terminator at column 0); the generated config is valid bash.
- Simulated config generation + sourcing under `set -u` with a hostile token value (`gh"s_$(touch PWNED)`…) — carried through as a literal string with no command execution or injection.

## Cutover (after merge, on `elpa-mirror`)

1. Merge this so `action.yml` is on `master` (needed for `uses: d12frosted/mirror-elpa@master`).
2. Add `examples/elpa-mirror.yaml` to `elpa-mirror` as `.github/workflows/mirror.yaml`.
3. Trigger it once via `workflow_dispatch` to confirm the push (if denied, set Settings → Actions → Workflow permissions to read/write).
4. Once confirmed, the old `ACCESS_LOGIN`/`ACCESS_TOKEN` secrets here can be removed.
