### PR TITLE
fix: don't put a ${{ secrets.* }} expression in an action input description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
   access_token:
     description: >-
       Token used to authenticate the push to the mirror repository. When the
-      workflow lives in the mirror repository itself, the built-in
-      ${{ secrets.GITHUB_TOKEN }} is enough (requires "contents: write").
+      workflow lives in the mirror repository itself, the built-in GITHUB_TOKEN
+      (secrets.GITHUB_TOKEN) is enough (requires "contents: write").
     required: true
   access_login:
     description: >-


### PR DESCRIPTION
The merged `action.yml` had `${{ secrets.GITHUB_TOKEN }}` inside the `access_token` **input description**. GitHub evaluates `${{ }}` templates in action-manifest descriptions, and `secrets` isn't a valid context there, so the composite action failed to load entirely:

```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
```

Caught it the moment I wired up the real schedule on `elpa-mirror` — the very first run died at "Set up job" before any step ran. Lint didn't catch it because it only `bash -n` / shellchecks the scripts, not the manifest.

Fix is just rewording the description to mention `GITHUB_TOKEN` as plain text (no template). No behavior change.