### PR TITLE
fix: authenticate nix's GitHub API calls when installing Emacs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,20 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # setup-emacs installs Emacs with `nix profile install github:purcell/...`,
+    # and nix resolves that github: reference through api.github.com. Without an
+    # access token nix calls it unauthenticated, which GitHub now throttles with
+    # HTTP 429 ("this endpoint is temporarily being throttled"), failing the
+    # install. nix reads the token from `access-tokens` in NIX_CONFIG (it does
+    # not pick up GITHUB_TOKEN on its own), so feed it the workflow token here.
+    - name: Authenticate nix GitHub API calls
+      if: ${{ inputs.emacs_version != '' }}
+      shell: bash
+      env:
+        GH_API_TOKEN: ${{ github.token }}
+      run: |
+        echo "NIX_CONFIG=access-tokens = github.com=${GH_API_TOKEN}" >>"$GITHUB_ENV"
+
     - name: Set up Emacs
       if: ${{ inputs.emacs_version != '' }}
       uses: purcell/setup-emacs@master


### PR DESCRIPTION
Wiring up the real schedule on `elpa-mirror` surfaced a second blocker: the `setup-emacs` step kept dying with HTTP 429.

`setup-emacs` installs Emacs via `nix profile install github:purcell/nix-emacs-ci#emacs-<version>`, and nix resolves that `github:` reference through `api.github.com`. Unauthenticated, GitHub throttles it ("this endpoint is temporarily being throttled") and the install fails before any mirroring happens. nix doesn't read the `GITHUB_TOKEN` env var that setup-emacs exports — it only authenticates when given an `access-tokens` entry — so we export `NIX_CONFIG=access-tokens = github.com=${{ github.token }}` right before the setup-emacs step.

Uses `github.token` (independent of the mirror's `access_token`, so it's correct even when mirroring to a non-GitHub host). Only runs when `emacs_version` is set.