### PR TITLE
fix: install Emacs via d12frosted/setup-emacs to dodge the API rate limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,25 +70,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # setup-emacs installs Emacs with `nix profile install github:purcell/...`,
-    # and nix resolves that github: reference through api.github.com. Called
-    # unauthenticated, GitHub throttles it with HTTP 429 ("this endpoint is
-    # temporarily being throttled") and the install fails before any mirroring
-    # runs. Install nix ourselves first with the workflow token written into the
-    # *system* nix.conf, which the nix daemon honours -- a token supplied via the
-    # client environment (NIX_CONFIG) is ignored for an untrusted runner user.
-    # setup-emacs reuses this nix instead of reinstalling, so its github: fetch
-    # is authenticated and no longer rate-limited.
-    - name: Install Nix with authenticated GitHub access
-      if: ${{ inputs.emacs_version != '' }}
-      uses: cachix/install-nix-action@v30
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ github.token }}
-
+    # Install Emacs via d12frosted/setup-emacs, which avoids the rate-limited
+    # api.github.com call that makes purcell/setup-emacs flaky on GitHub-hosted
+    # runners (HTTP 429 "temporarily being throttled"). See that action's README
+    # for the full story.
     - name: Set up Emacs
       if: ${{ inputs.emacs_version != '' }}
-      uses: purcell/setup-emacs@master
+      uses: d12frosted/setup-emacs@v1
       with:
         version: ${{ inputs.emacs_version }}
 


### PR DESCRIPTION
Swaps the inlined nix + purcell/setup-emacs steps for our own [d12frosted/setup-emacs](https://github.com/d12frosted/setup-emacs) action.

We chased the `setup-emacs` 429s for a while and finally pinned it down in a sandbox: it's a **secondary** (anti-scraping) rate limit on the shared GitHub-runner IP hitting `api.github.com/repos/purcell/nix-emacs-ci/commits/HEAD`, and **authentication doesn't bypass it** (an authenticated request 429s with a full 5000/hr quota unused). So the earlier auth fix (#9, #10) was a dead end.

The new action sidesteps `api.github.com` entirely — installs the same nix-emacs-ci Emacs from the codeload tarball + the `emacs-ci` Cachix cache (clean run ~20s, verified on Linux + macOS). One source of truth I can reuse across all the Emacs repos.

This removes the now-useless `access-tokens` nix config and the dependency on `purcell/setup-emacs` here.