### PR TITLE
fix: clone the mirror repo when mirror_path isn't a checkout

### DIFF
--- a/mirror-elpa
+++ b/mirror-elpa
@@ -64,7 +64,12 @@ else
   )
 fi
 
-if [[ ! -d "$mirror_path" ]]; then
+# Clone unless mirror_path is already a checkout. Guard on the .git dir rather
+# than the directory itself: when mirror_path is unset we point it at a fresh
+# `mktemp -d`, which already exists (empty), so a plain `-d "$mirror_path"`
+# check would wrongly skip the clone and leave us syncing into a non-repo --
+# elpa-clone then re-downloads everything and nothing can be committed/pushed.
+if [[ ! -d "$mirror_path/.git" ]]; then
   log "cloning mirror repository"
   git clone --depth 1 "$mirror_url" "$mirror_path"
 fi


### PR DESCRIPTION
Found while verifying the elpa-mirror cron. With an unset `mirror_path` (the composite action's default), the script points it at a fresh `mktemp -d` — which already exists (empty). The old `[[ ! -d "$mirror_path" ]]` guard then saw the directory and **skipped cloning the mirror repo**, so elpa-clone synced into an empty non-git dir:

- every package looked new → full, slow re-download (the http "polling" slowness — not the sync method)
- the dir wasn't a git checkout, so the commit/push block found no `.git` and silently pushed nothing

The old cron avoided this only because `.ci/*.config` set `mirror_path` to a *non-existent* relative path. Guard on `$mirror_path/.git` instead (cloning into the empty mktemp dir is fine), restoring incremental syncs and the snapshot push.

Unrelated aside confirmed while debugging: GNU/NonGNU stay on `https` on purpose — their rsync modules serve a different (`.tar.lz`, multi-version, no-readme) layout than the `packages/` presentation the mirror publishes.