### PR TITLE
feat: default committer to github-actions[bot]

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,8 +38,8 @@ Example of configuration file:
   mirror_repo="elpa-mirror"
   access_login="$ACCESS_LOGIN"
   access_token="$ACCESS_TOKEN"
-  commit_name="Golem"
-  commit_email="golem@d12frosted.io"
+  commit_name="Your Name"
+  commit_email="you@example.com"
   elpa_clone_path="$XDG_CACHE_HOME/elpa-clone"
 
   function git_config_hook {
@@ -116,8 +116,8 @@ the job grants =contents: write=.
 | =access_login=            | no       | =x-access-token=                       | Login paired with =access_token=.                        |
 | =mirror_host=             | no       | =github.com=                           | Git host of the mirror remote.                           |
 | =mirror_repo_branch_name= | no       | =master=                               | Branch to push to.                                       |
-| =commit_name=             | no       | =mirror-elpa=                          | Committer name.                                          |
-| =commit_email=            | no       | =mirror-elpa@users.noreply.github.com= | Committer email.                                         |
+| =commit_name=             | no       | =github-actions[bot]=                  | Committer name.                                          |
+| =commit_email=            | no       | =41898282+github-actions[bot]@users.noreply.github.com= | Committer email.                       |
 | =commit_gpgsign=          | no       | =false=                                | Whether to GPG-sign snapshot commits.                   |
 | =mirror_path=             | no       | temporary directory                    | Local working path for the mirror checkout.             |
 | =elpa_clone_path=         | no       | =$HOME/.cache/elpa-clone=              | Local path for the elpa-clone tool.                     |

--- a/action.yml
+++ b/action.yml
@@ -35,11 +35,11 @@ inputs:
   commit_name:
     description: 'Committer name used for snapshot commits.'
     required: false
-    default: 'mirror-elpa'
+    default: 'github-actions[bot]'
   commit_email:
     description: 'Committer email used for snapshot commits.'
     required: false
-    default: 'mirror-elpa@users.noreply.github.com'
+    default: '41898282+github-actions[bot]@users.noreply.github.com'
   commit_gpgsign:
     description: 'Whether to GPG-sign snapshot commits.'
     required: false

--- a/examples/elpa-mirror.yaml
+++ b/examples/elpa-mirror.yaml
@@ -39,9 +39,9 @@ jobs:
           mirror_repo: elpa-mirror
           access_login: x-access-token
           access_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_name: Golem
-          commit_email: golem@d12frosted.io
-          emacs_version: '28.1'
+          emacs_version: '30.2'
+          # committer defaults to github-actions[bot]; override commit_name /
+          # commit_email if you want a different identity.
 
       # --- Mirroring to another remote as well? ---------------------------
       # The same repository can be mirrored elsewhere by adding another step
@@ -56,5 +56,3 @@ jobs:
       #     mirror_repo: elpa-mirror
       #     access_login: ${{ secrets.OTHER_USER }}
       #     access_token: ${{ secrets.OTHER_ACCESS_TOKEN }}
-      #     commit_name: Golem
-      #     commit_email: golem@d12frosted.io


### PR DESCRIPTION
Drops the dedicated `Golem` machine account in favor of the built-in GitHub Actions bot for snapshot commits, so there's one less identity to manage. Snapshots will show up attributed to `github-actions[bot]` (with the bot avatar).

- `action.yml`: committer defaults are now `github-actions[bot]` / `41898282+github-actions[bot]@users.noreply.github.com`.
- `examples/elpa-mirror.yaml`: drop the explicit `Golem` override (rely on the default); bump the example `emacs_version` to `30.2` (snapshot crashes elpa-clone).
- `README.org`: update the inputs-table defaults; the local/CRON config example uses a neutral placeholder instead of Golem.