### PR TITLE
feat: mirror GNU-devel and NonGNU-devel; drop dead Org ELPA

### DIFF
--- a/mirror-elpa
+++ b/mirror-elpa
@@ -74,9 +74,10 @@ if [[ ! -d "$mirror_path/.git" ]]; then
   git clone --depth 1 "$mirror_url" "$mirror_path"
 fi
 
-clone "http://orgmode.org/elpa/" "org"
 clone "https://elpa.gnu.org/packages/" "gnu"
+clone "https://elpa.gnu.org/devel/" "gnu-devel"
 clone "https://elpa.nongnu.org/nongnu/" "nongnu"
+clone "https://elpa.nongnu.org/nongnu-devel/" "nongnu-devel"
 clone "rsync://melpa.org/packages/" "melpa"
 clone "rsync://stable.melpa.org/packages/" "stable-melpa"
 


### PR DESCRIPTION
Rounding out the archive coverage.

**Add** the `-devel` archives (VCS/nightly builds, same presentation layout as the stable ones):
- `https://elpa.gnu.org/devel/` -> `gnu-devel` (~529 pkgs)
- `https://elpa.nongnu.org/nongnu-devel/` -> `nongnu-devel` (~294 pkgs)

**Drop** Org ELPA: `orgmode.org/elpa` is dead (its `archive-contents` is 185 bytes over both http and https; Org ships via GNU ELPA now), so it only mirrored stale/redirect content.

Heads up: the *first* run after this will be slow (it downloads all ~820 devel packages fresh via the https/url path); subsequent runs are incremental. The stale `org/` directory in elpa-mirror will be removed separately.